### PR TITLE
refactor: replace debug screenshot with error screenshot in request meta

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,9 +36,9 @@ The package exposes two public symbols (re-exported from `__init__.py`):
   - `__init__` takes only a `Crawler` and reads the `SELENIUMBASE_BROWSER_OPTIONS` setting from it (dict of kwargs forwarded to `cdp_driver.start_async`).
   - **Event-driven page load**: after `browser.get()`, two `asyncio.Event`s are awaited — one for the HTTP response status (`ResponseReceived`) and one for page load (`LoadComplete`). Both are gathered with `asyncio.wait_for(timeout=request.page_load_timeout)`. On timeout, processing continues with a warning.
   - **Captcha solving loop**: after page load, a delay is applied based on the HTTP status code (`captcha_delay` for 2xx, `captcha_blocked_delay` for codes in `captcha_blocked_codes`). Then `tab.solve_captcha()` is called in a loop up to `captcha_max_attempts` times, sleeping `delay` seconds between each attempt. If max attempts are exhausted, a warning is logged and processing continues.
-  - **`_wait_for_element` timeout**: raises `IgnoreRequest` (after taking a debug screenshot), which causes Scrapy to skip the request.
+  - **`_wait_for_element` timeout**: captures a full-page error screenshot (stored in `request.meta['error_screenshot']`) and raises `IgnoreRequest`, which causes Scrapy to skip the request. The screenshot is accessible in the spider's `errback` via `failure.request.meta['error_screenshot']`.
   - Per-request results are stored in `response.meta`: `'callback'`, `'script'`, `'screenshot'`.
-  - Errors in `_execute_callback`, `_execute_script`, and `_take_screenshot` are caught by the `@_handle_errors` decorator (a `@staticmethod` on the class that accesses the spider via `self.crawler.spider`) and logged — they do **not** abort the request.
+  - Errors in `_execute_callback`, `_execute_script`, `_take_screenshot`, and `_take_error_screenshot` are caught by the `@_handle_errors` decorator (a `@staticmethod` on the class that accesses the spider via `self.crawler.spider`) and logged — they do **not** abort the request.
 
 ## Key Conventions
 

--- a/README.md
+++ b/README.md
@@ -118,16 +118,32 @@ Available captcha configuration:
 
 When used, SeleniumBase will wait for the element with the given CSS selector
 to appear. The default timeout value is of 10 seconds but can be changed if
-needed. If the element is not found within the timeout, the request is skipped
-(Scrapy's `IgnoreRequest` is raised) and a full-page debug screenshot is saved
-using SeleniumBase's default path.
+needed. If the element is not found within the timeout, a full-page error
+screenshot is captured and stored in `request.meta['error_screenshot']`, then
+the request is skipped (Scrapy's `IgnoreRequest` is raised). The screenshot
+image format is taken from the request's `screenshot` configuration if set,
+otherwise it defaults to PNG.
+
+The error screenshot is accessible in the request's `errback` via
+`failure.request.meta['error_screenshot']`:
 
 ```python
+from scrapy.spidermiddlewares.httperror import HttpError
+from twisted.internet.error import DNSLookupError, TimeoutError
+
 yield SeleniumBaseRequest(
     url=url,
     callback=self.parse_result,
+    errback=self.handle_error,
     wait_for_element='h1.some-class',
     element_timeout=5)
+
+
+def handle_error(self, failure):
+    screenshot = failure.request.meta.get('error_screenshot')
+    if screenshot:
+        with open('error.png', 'wb') as f:
+            f.write(screenshot)
 ```
 
 #### `browser_callback`
@@ -212,9 +228,11 @@ determine captcha-solving behaviour (see [Captcha handling](#captcha-handling)
 above).
 
 - **`wait_for_element` timeout**: if the expected element is not found within
-  `element_timeout` seconds, a full-page debug screenshot is saved using
-  SeleniumBase's default path and `IgnoreRequest` is raised, causing Scrapy to
-  skip the request.
+  `element_timeout` seconds, a full-page error screenshot is captured and stored
+  in `request.meta['error_screenshot']`, then `IgnoreRequest` is raised, causing
+  Scrapy to skip the request. The screenshot is accessible in the request's
+  `errback` via `failure.request.meta['error_screenshot']` (see
+  [`wait_for_element`](#wait_for_element--element_timeout) for an example).
 
 ## Tips for headless Linux environments
 

--- a/scrapy_seleniumbase_cdp/middleware_async.py
+++ b/scrapy_seleniumbase_cdp/middleware_async.py
@@ -89,6 +89,8 @@ class SeleniumBaseAsyncCDPMiddleware:
 
         try:
             return await self._process_request(request, status_event, page_loaded_event, status)
+        except IgnoreRequest:
+            raise
         except Exception as e:
             self.crawler.spider.logger.exception(f'Error processing request: {e}')
             raise IgnoreRequest(f'Error processing request: {e}')
@@ -152,7 +154,7 @@ class SeleniumBaseAsyncCDPMiddleware:
             await tab.wait_for(selector=request.wait_for_element, timeout=request.element_timeout)
         except TimeoutError:
             self.crawler.spider.logger.error(f'Timed out waiting for element "{request.wait_for_element}" on {request.url}')
-            await self._take_debug_screenshot(tab)
+            await self._take_error_screenshot(tab, request)
             raise IgnoreRequest(f'Element "{request.wait_for_element}" not found within {request.element_timeout} seconds')
 
     @_handle_errors("Error executing browser callback")
@@ -189,11 +191,24 @@ class SeleniumBaseAsyncCDPMiddleware:
             request.meta['screenshot'] = b64decode(await tab.send(command))
             self.crawler.spider.logger.debug('Screenshot saved in response.meta["screenshot"]')
 
-    @_handle_errors("Error taking debug screenshot")
-    async def _take_debug_screenshot(self, tab: Tab):
-        """Take a full-page debug screenshot using SeleniumBase's default path."""
-        path = await tab.save_screenshot('auto', 'png', True)
-        self.crawler.spider.logger.info(f'Debug screenshot saved in {path}')
+    @_handle_errors("Error taking error screenshot")
+    async def _take_error_screenshot(self, tab: Tab, request: SeleniumBaseRequest):
+        """Take a screenshot on error and store it in ``request.meta['error_screenshot']``.
+
+        Uses the image format from the request's screenshot configuration if available,
+        otherwise defaults to a full-page PNG. Always captures the full page regardless
+        of the user's ``full_page`` setting, to maximise diagnostic value.
+
+        The screenshot is accessible in the spider's errback via
+        ``failure.request.meta['error_screenshot']``.
+        """
+        image_format = 'png'
+        if request.screenshot and isinstance(request.screenshot, dict):
+            image_format = request.screenshot.get('format', 'png')
+
+        command = mycdp.page.capture_screenshot(format_=image_format, capture_beyond_viewport=True)
+        request.meta['error_screenshot'] = b64decode(await tab.send(command))
+        self.crawler.spider.logger.debug(f'Error screenshot saved in request.meta["error_screenshot"]: {request.url}')
 
     async def spider_opened(self, spider):
         """Start the CDP browser when the spider opens."""


### PR DESCRIPTION
## Summary

Replaces `_take_debug_screenshot` (which saved a screenshot to disk via SeleniumBase's default path) with `_take_error_screenshot` that captures the screenshot bytes and stores them in `request.meta['error_screenshot']`.

### Changes

- **New `_take_error_screenshot` method**: captures a full-page screenshot and stores it in `request.meta['error_screenshot']`. Uses the image format from the request's `screenshot` config if set, otherwise defaults to PNG. Always captures full-page regardless of user's `full_page` setting to maximise diagnostic value.
- **Removed `_take_debug_screenshot`**: no longer saves screenshots to disk on element timeout.
- **Fixed `IgnoreRequest` passthrough**: `IgnoreRequest` raised by `_wait_for_element` now propagates directly through `process_request`'s exception handler instead of being wrapped in a new generic `IgnoreRequest`.
- **Updated README**: `wait_for_element` section now documents the error screenshot behaviour with an `errback` example.
- **Updated copilot-instructions.md**: reflects the new `_take_error_screenshot` method and `error_screenshot` meta key.

### How to access the error screenshot

```python
yield SeleniumBaseRequest(
    url=url,
    callback=self.parse_result,
    errback=self.handle_error,
    wait_for_element='h1.some-class')

def handle_error(self, failure):
    screenshot = failure.request.meta.get('error_screenshot')
    if screenshot:
        with open('error.png', 'wb') as f:
            f.write(screenshot)
```