### PR TITLE
refactor: use module-level logger instead of spider logger

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,7 +38,7 @@ The package exposes two public symbols (re-exported from `__init__.py`):
   - **Captcha solving loop**: after page load, a delay is applied based on the HTTP status code (`captcha_delay` for 2xx, `captcha_blocked_delay` for codes in `captcha_blocked_codes`). Then `tab.solve_captcha()` is called in a loop up to `captcha_max_attempts` times, sleeping `delay` seconds between each attempt. If max attempts are exhausted, a warning is logged and processing continues.
   - **`_wait_for_element` timeout**: captures a full-page error screenshot (stored in `request.meta['error_screenshot']`) and raises `IgnoreRequest`, which causes Scrapy to skip the request. The screenshot is accessible in the spider's `errback` via `failure.request.meta['error_screenshot']`.
   - Per-request results are stored in `response.meta`: `'callback'`, `'script'`, `'screenshot'`.
-  - Errors in `_execute_callback`, `_execute_script`, `_take_screenshot`, and `_take_error_screenshot` are caught by the `@_handle_errors` decorator (a `@staticmethod` on the class that accesses the spider via `self.crawler.spider`) and logged — they do **not** abort the request.
+  - Errors in `_execute_callback`, `_execute_script`, `_take_screenshot`, and `_take_error_screenshot` are caught by the `_handle_errors` module-level decorator and logged via the module-level logger — they do **not** abort the request. Methods that do not access instance state (`_execute_script`, `_take_screenshot`, `_take_error_screenshot`, `_wait_for_element`) are `@staticmethod`s.
 
 ## Key Conventions
 
@@ -46,5 +46,5 @@ The package exposes two public symbols (re-exported from `__init__.py`):
 - The middleware must use async/await (`cdp_driver`'s async API) because pure CDP mode has its own event loop that conflicts with Scrapy's Twisted loop.
 - `SeleniumBaseRequest` kwargs mirror the README documentation exactly — keep them in sync when adding new features.
 - Version is maintained solely in `pyproject.toml` under `[project] version`; `commitizen` updates it automatically — do not edit it manually.
-- **Logging**: all operational log messages use `DEBUG` level. Only warnings (e.g. page load timeout, max captcha attempts) and errors (e.g. element wait timeout) use higher levels. Log messages are lowercase and include the request URL for traceability.
+- **Logging**: all operational log messages use `DEBUG` level via a module-level logger (`logging.getLogger(__name__)`). Warnings (e.g. page load timeout, max captcha attempts) and errors (e.g. element wait timeout) use higher levels. Log messages are lowercase and include the request URL for traceability. The logger name is `scrapy_seleniumbase_cdp.middleware_async`.
 - See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for a detailed overview of the middleware internals, including a mermaid sequence diagram.

--- a/README.md
+++ b/README.md
@@ -276,9 +276,10 @@ Then connect from any VNC client to `<host>:5900`. Key flags:
 ## Enabling debug logs
 
 The middleware logs operational details (page load events, captcha attempts,
-screenshot captures, etc.) at the `DEBUG` level. Warnings and errors (page load
-timeouts, element wait timeouts, max captcha attempts reached) use higher log
-levels and are always visible.
+screenshot captures, etc.) at the `DEBUG` level. Log messages are emitted under
+the `scrapy_seleniumbase_cdp.middleware_async` logger name. Warnings and errors
+(page load timeouts, element wait timeouts, max captcha attempts reached) use
+higher log levels and are always visible.
 
 To see all debug output, set Scrapy's global log level in your `settings.py`:
 
@@ -287,13 +288,17 @@ LOG_LEVEL = 'DEBUG'
 ```
 
 If you prefer to keep Scrapy's own output at a higher level and only enable
-debug logging for this middleware, configure the logger directly:
+debug logging for this middleware, configure the parent logger directly:
 
 ```python
 # settings.py or spider __init__
 import logging
 logging.getLogger('scrapy_seleniumbase_cdp').setLevel(logging.DEBUG)
 ```
+
+This works because the middleware uses a module-level logger named
+`scrapy_seleniumbase_cdp.middleware_async`, which inherits settings from the
+`scrapy_seleniumbase_cdp` parent logger.
 
 You can also use Scrapy's per-module log configuration via the
 [`LOG_CATEGORIES`][6] setting (Scrapy ≥ 2.8):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -136,9 +136,9 @@ After captcha handling, the middleware executes optional steps in order:
 
 #### Error handling
 
-- The `@_handle_errors` decorator wraps the callback, script, and screenshot
-  methods. It catches exceptions and logs them but does **not** abort the
-  request — partial results are still returned.
+- The `_handle_errors` module-level decorator wraps the callback, script, and
+  screenshot methods. It catches exceptions and logs them via the module-level
+  logger but does **not** abort the request — partial results are still returned.
 - An unrecoverable error in the main pipeline raises `IgnoreRequest`, causing
   Scrapy to skip the request entirely.
 

--- a/scrapy_seleniumbase_cdp/middleware_async.py
+++ b/scrapy_seleniumbase_cdp/middleware_async.py
@@ -227,7 +227,7 @@ class SeleniumBaseAsyncCDPMiddleware:
 
         logger.debug(f'executing script: {request.url}')
         request.meta['script'] = await tab.evaluate(request.script['script'],
-                                                     await_promise=request.script.get('await_promise', False))
+                                                    await_promise=request.script.get('await_promise', False))
 
     @staticmethod
     @_handle_errors("Error taking screenshot")

--- a/scrapy_seleniumbase_cdp/middleware_async.py
+++ b/scrapy_seleniumbase_cdp/middleware_async.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from asyncio import Event
 from base64 import b64decode
 from functools import wraps
@@ -15,6 +16,29 @@ from seleniumbase.undetected.cdp_driver.browser import Browser
 from seleniumbase.undetected.cdp_driver.tab import Tab
 
 from .request import SeleniumBaseRequest
+
+logger = logging.getLogger(__name__)
+
+
+def _handle_errors(error_msg: str):
+    """Decorator that catches and logs exceptions from async middleware methods.
+
+    Wrapped methods log the error but do **not** abort the request — processing
+    continues so that partial results (e.g. page source without a screenshot) are
+    still returned to the spider.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            try:
+                return await func(*args, **kwargs)
+            except Exception as e:
+                logger.exception(f'{error_msg}: {e}')
+
+        return wrapper
+
+    return decorator
 
 
 class SeleniumBaseAsyncCDPMiddleware:
@@ -57,27 +81,6 @@ class SeleniumBaseAsyncCDPMiddleware:
         crawler.signals.connect(middleware.spider_closed, signals.spider_closed)
         return middleware
 
-    @staticmethod
-    def _handle_errors(error_msg: str):
-        """Decorator that catches and logs exceptions from async middleware methods.
-
-        Wrapped methods log the error but do **not** abort the request — processing
-        continues so that partial results (e.g. page source without a screenshot) are
-        still returned to the spider.
-        """
-
-        def decorator(func):
-            @wraps(func)
-            async def wrapper(self, *args, **kwargs):
-                try:
-                    return await func(self, *args, **kwargs)
-                except Exception as e:
-                    self.crawler.spider.logger.exception(f'{error_msg}: {e}')
-
-            return wrapper
-
-        return decorator
-
     async def process_request(self, request: Request):
         """Process a request using the CDP browser if it is a ``SeleniumBaseRequest``.
 
@@ -93,7 +96,7 @@ class SeleniumBaseAsyncCDPMiddleware:
         if not isinstance(request, SeleniumBaseRequest):
             return None
 
-        self.crawler.spider.logger.debug(f'processing request: {request.url}')
+        logger.debug(f'processing request: {request.url}')
 
         status = {'code': 200}
         status_event = Event()
@@ -104,13 +107,13 @@ class SeleniumBaseAsyncCDPMiddleware:
                 return
             status['code'] = e.response.status
             status_event.set()
-            self.crawler.spider.logger.debug(f'response received: [{e.response.status}] {e.response.url}')
+            logger.debug(f'response received: [{e.response.status}] {e.response.url}')
 
         def on_load_complete(e: LoadComplete, connection=None):
             url = next((p.value.value for p in e.root.properties if p.name.value == 'url'), None)
             if url not in request.url:
                 return
-            self.crawler.spider.logger.debug(f'page loaded: {url}')
+            logger.debug(f'page loaded: {url}')
             page_loaded_event.set()
 
         tab = self.browser.main_tab
@@ -125,7 +128,7 @@ class SeleniumBaseAsyncCDPMiddleware:
         except IgnoreRequest:
             raise
         except Exception as e:
-            self.crawler.spider.logger.exception(f'Error processing request: {e}')
+            logger.exception(f'Error processing request: {e}')
             raise IgnoreRequest(f'Error processing request: {e}')
         finally:
             tab.handlers.get(ResponseReceived, []).remove(on_response_received)
@@ -146,12 +149,12 @@ class SeleniumBaseAsyncCDPMiddleware:
             8. Build and return an ``HtmlResponse``.
         """
         tab: Tab = await self.browser.get(request.url)
-        self.crawler.spider.logger.debug(f'navigating to: {request.url}')
+        logger.debug(f'navigating to: {request.url}')
 
         try:
             await asyncio.wait_for(asyncio.gather(status_event.wait(), page_loaded_event.wait()), timeout=request.page_load_timeout)
         except TimeoutError:
-            self.crawler.spider.logger.warning(f'Timed out waiting for page to load: {request.url}')
+            logger.warning(f'Timed out waiting for page to load: {request.url}')
 
         status_code = status['code']
         if status_code in request.captcha_blocked_codes:
@@ -162,11 +165,11 @@ class SeleniumBaseAsyncCDPMiddleware:
         for attempt in range(request.captcha_max_attempts):
             await asyncio.sleep(delay)
             if not await tab.solve_captcha():
-                self.crawler.spider.logger.debug(f'no captcha detected: {request.url}')
+                logger.debug(f'no captcha detected: {request.url}')
                 break
-            self.crawler.spider.logger.debug(f'captcha solved on attempt {attempt + 1}/{request.captcha_max_attempts}: {request.url}')
+            logger.debug(f'captcha solved on attempt {attempt + 1}/{request.captcha_max_attempts}: {request.url}')
         else:
-            self.crawler.spider.logger.warning(f'Max captcha solve attempts ({request.captcha_max_attempts}) reached for {request.url}')
+            logger.warning(f'Max captcha solve attempts ({request.captcha_max_attempts}) reached for {request.url}')
 
         await self._wait_for_element(tab, request)
         await self._execute_callback(request)
@@ -187,7 +190,8 @@ class SeleniumBaseAsyncCDPMiddleware:
                             status=status_code,
                             headers={'Cookie': '; '.join(cookies)})
 
-    async def _wait_for_element(self, tab: Tab, request: SeleniumBaseRequest):
+    @staticmethod
+    async def _wait_for_element(tab: Tab, request: SeleniumBaseRequest):
         """Wait for the specified element if requested.
 
         Raises:
@@ -196,13 +200,13 @@ class SeleniumBaseAsyncCDPMiddleware:
         if not request.wait_for_element:
             return
 
-        self.crawler.spider.logger.debug(f'waiting for element "{request.wait_for_element}" (timeout: {request.element_timeout}s): {request.url}')
+        logger.debug(f'waiting for element "{request.wait_for_element}" (timeout: {request.element_timeout}s): {request.url}')
 
         try:
             await tab.wait_for(selector=request.wait_for_element, timeout=request.element_timeout)
         except TimeoutError:
-            self.crawler.spider.logger.error(f'Timed out waiting for element "{request.wait_for_element}" on {request.url}')
-            await self._take_error_screenshot(tab, request)
+            logger.error(f'Timed out waiting for element "{request.wait_for_element}" on {request.url}')
+            await SeleniumBaseAsyncCDPMiddleware._take_error_screenshot(tab, request)
             raise IgnoreRequest(f'Element "{request.wait_for_element}" not found within {request.element_timeout} seconds')
 
     @_handle_errors("Error executing browser callback")
@@ -211,40 +215,43 @@ class SeleniumBaseAsyncCDPMiddleware:
         if not request.browser_callback:
             return
 
-        self.crawler.spider.logger.debug(f'executing browser callback: {request.url}')
+        logger.debug(f'executing browser callback: {request.url}')
         request.meta['callback'] = await request.browser_callback(self.browser)
 
+    @staticmethod
     @_handle_errors("Error executing script")
-    async def _execute_script(self, tab: Tab, request: SeleniumBaseRequest):
+    async def _execute_script(tab: Tab, request: SeleniumBaseRequest):
         """Execute the JavaScript code if requested."""
         if not request.script or not request.script.get('script'):
             return
 
-        self.crawler.spider.logger.debug(f'executing script: {request.url}')
+        logger.debug(f'executing script: {request.url}')
         request.meta['script'] = await tab.evaluate(request.script['script'],
-                                                    await_promise=request.script.get('await_promise', False))
+                                                     await_promise=request.script.get('await_promise', False))
 
+    @staticmethod
     @_handle_errors("Error taking screenshot")
-    async def _take_screenshot(self, tab: Tab, request: SeleniumBaseRequest):
+    async def _take_screenshot(tab: Tab, request: SeleniumBaseRequest):
         """Take a screenshot if requested."""
         if not request.screenshot:
             return
 
-        self.crawler.spider.logger.debug(f'taking screenshot: {request.url}')
+        logger.debug(f'taking screenshot: {request.url}')
 
         image_format = request.screenshot.get('format', 'png')
         full_page = request.screenshot.get('full_page', True)
 
         if request.screenshot.get('path'):
             path = await tab.save_screenshot(request.screenshot.get('path'), image_format, full_page)
-            self.crawler.spider.logger.debug(f'Screenshot saved in {path}')
+            logger.debug(f'Screenshot saved in {path}')
         else:
             command = mycdp.page.capture_screenshot(format_=image_format, capture_beyond_viewport=full_page)
             request.meta['screenshot'] = b64decode(await tab.send(command))
-            self.crawler.spider.logger.debug('Screenshot saved in response.meta["screenshot"]')
+            logger.debug('Screenshot saved in response.meta["screenshot"]')
 
+    @staticmethod
     @_handle_errors("Error taking error screenshot")
-    async def _take_error_screenshot(self, tab: Tab, request: SeleniumBaseRequest):
+    async def _take_error_screenshot(tab: Tab, request: SeleniumBaseRequest):
         """Take a screenshot on error and store it in ``request.meta['error_screenshot']``.
 
         Uses the image format from the request's screenshot configuration if available,
@@ -260,14 +267,14 @@ class SeleniumBaseAsyncCDPMiddleware:
 
         command = mycdp.page.capture_screenshot(format_=image_format, capture_beyond_viewport=True)
         request.meta['error_screenshot'] = b64decode(await tab.send(command))
-        self.crawler.spider.logger.debug(f'error screenshot saved in request.meta["error_screenshot"]: {request.url}')
+        logger.debug(f'error screenshot saved in request.meta["error_screenshot"]: {request.url}')
 
     async def spider_opened(self, spider):
         """Start the CDP browser when the spider opens."""
         self.browser = await cdp_driver.start_async(**self.browser_options)
-        spider.logger.debug('browser started')
+        logger.debug('browser started')
 
     def spider_closed(self, spider):
         """Stop the browser when the spider closes."""
         self.browser.stop()
-        spider.logger.debug('browser stopped')
+        logger.debug('browser stopped')


### PR DESCRIPTION
## Summary

Replace all uses of `self.crawler.spider.logger` / `spider.logger` (Scrapy's `SpiderLoggerAdapter`) with a standard module-level logger (`logging.getLogger(__name__)`) in `middleware_async.py`. As a cascading effect, move `_handle_errors` to module level and promote methods that no longer access instance state to `@staticmethod`.

## Why

`self.crawler.spider.logger` is Scrapy's spider-scoped logger adapter. While it works, it is unconventional for middleware/library code and couples every log call to the spider instance. The standard Python pattern for libraries and middleware is a module-level logger.

## What changed

- **`middleware_async.py`**:
  - Added `import logging` + `logger = logging.getLogger(__name__)` at module level; replaced all 21 logger calls
  - Moved `_handle_errors` from `@staticmethod` on the class to a module-level function (no longer needs class access); changed wrapper signature from `wrapper(self, *args)` to `wrapper(*args)` since `self` was only passed through
  - Promoted `_wait_for_element`, `_execute_script`, `_take_screenshot`, `_take_error_screenshot` to `@staticmethod` (none access instance state after the logger change)
  - `_execute_callback` remains an instance method (uses `self.browser`)
- **`README.md`**: clarified that logs emit under `scrapy_seleniumbase_cdp.middleware_async` and explained parent logger filtering
- **`.github/copilot-instructions.md`**: updated logging convention and `_handle_errors` description
- **`docs/ARCHITECTURE.md`**: updated error handling description

## Pros

- **Standard Python pattern** — `logging.getLogger(__name__)` is the recommended approach for library/middleware code ([Python logging docs](https://docs.python.org/3/howto/logging.html#advanced-logging-tutorial))
- **Hierarchical logger filtering** — `logging.getLogger('scrapy_seleniumbase_cdp').setLevel(logging.DEBUG)` covers all submodules automatically
- **Cleaner code** — no need to access `self.crawler.spider` just for logging; methods that are pure functions of their arguments are now `@staticmethod`
- **Consistent with README** — the existing debug logging docs already recommended filtering on `scrapy_seleniumbase_cdp`, which now matches the actual logger name

## Cons

- **Logger name changes** — log messages appear under `scrapy_seleniumbase_cdp.middleware_async` instead of the spider name (e.g. `my_spider`). Users filtering by spider name will no longer see middleware logs there.
- **Loses `SpiderLoggerAdapter` context** — Scrapy's adapter injects `extra={"spider": spider}` into log records. Custom formatters/handlers relying on `record.spider` will no longer receive it from middleware logs. This is acceptable since the middleware runs one-spider-per-crawler.