### PR TITLE
fix: declare custom attributes for copy/replace support

### DIFF
--- a/scrapy_seleniumbase_cdp/request.py
+++ b/scrapy_seleniumbase_cdp/request.py
@@ -35,6 +35,19 @@ class ScriptConfig(TypedDict):
 class SeleniumBaseRequest(Request):
     """Subclass of Scrapy ``Request`` providing additional arguments"""
 
+    attributes = Request.attributes + (
+        'page_load_timeout',
+        'captcha_delay',
+        'captcha_blocked_delay',
+        'captcha_blocked_codes',
+        'captcha_max_attempts',
+        'wait_for_element',
+        'element_timeout',
+        'browser_callback',
+        'script',
+        'screenshot',
+    )
+
     def __init__(self,
                  page_load_timeout: int = 10,
                  captcha_delay: float = 0,


### PR DESCRIPTION
## Problem

`SeleniumBaseRequest` stores custom parameters (`wait_for_element`, `script`, `screenshot`, `page_load_timeout`, etc.) as instance attributes but does not declare them in Scrapy's `attributes` tuple.

Scrapy's `Request.copy()` and `Request.replace()` methods use the `attributes` tuple to determine which values to pass when reconstructing a request. Without the custom attributes declared, all SeleniumBase-specific configuration is silently lost on copy.

This breaks Scrapy's built-in `RetryMiddleware`, which calls `request.copy()` to create retry requests — retried `SeleniumBaseRequest`s would revert to default values for all custom parameters.

## Fix

Override `attributes` on `SeleniumBaseRequest` to extend `Request.attributes` with all custom fields. This is the standard Scrapy pattern used by `FormRequest` and `JsonRequest`.

## Verification

```python
req = SeleniumBaseRequest(
    url='https://example.com',
    wait_for_element='h1.title',
    screenshot=True,
    script='document.title',
    page_load_timeout=20,
)

copy = req.copy()
assert copy.wait_for_element == 'h1.title'
assert copy.screenshot == {'format': 'png', 'full_page': True}
assert copy.script == {'script': 'document.title', 'await_promise': False}
assert copy.page_load_timeout == 20
assert type(copy) is SeleniumBaseRequest
```